### PR TITLE
Add CODEOWNERS to match otel-arrow repo

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,17 @@
+#####################################################
+#
+# List of approvers for this repository
+#
+#####################################################
+#
+# Learn about membership in OpenTelemetry community:
+#  https://github.com/open-telemetry/community/blob/main/community-membership.md
+#
+#
+# Learn about CODEOWNERS file format:
+#  https://help.github.com/en/articles/about-code-owners
+#
+
+* @lquerel @jmacd
+
+CODEOWNERS @lquerel @jmacd


### PR DESCRIPTION
**Description:** Adds CODEOWNERS to match the otel-arrow repository.

**Link to tracking Issue:** https://github.com/open-telemetry/otel-arrow/issues/3

